### PR TITLE
fix(alpha): handle ALPH compressed payload without VP8L header

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -2,12 +2,15 @@ package webp
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"image"
 	"image/color"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/deepteams/webp/internal/lossless"
 )
 
 // --- Options / Defaults tests ---
@@ -110,6 +113,48 @@ func gradientTestImage(w, h int) *image.NRGBA {
 		}
 	}
 	return img
+}
+
+func findRIFFChunk(data []byte, fourcc string) ([]byte, bool) {
+	if len(data) < 12 {
+		return nil, false
+	}
+	for off := 12; off+8 <= len(data); {
+		id := string(data[off : off+4])
+		size := int(binary.LittleEndian.Uint32(data[off+4 : off+8]))
+		payloadOff := off + 8
+		if size < 0 || payloadOff+size > len(data) {
+			return nil, false
+		}
+		if id == fourcc {
+			return data[payloadOff : payloadOff+size], true
+		}
+		off = payloadOff + size
+		if size&1 != 0 {
+			off++
+		}
+	}
+	return nil, false
+}
+
+func vp8LStreamForAlphaPayload(payload []byte, width, height int) []byte {
+	stream := make([]byte, lossless.VP8LHeaderSize+len(payload))
+	stream[0] = lossless.VP8LMagicByte
+	bits := uint32(width-1) | uint32(height-1)<<lossless.VP8LImageSizeBits
+	binary.LittleEndian.PutUint32(stream[1:5], bits)
+	copy(stream[lossless.VP8LHeaderSize:], payload)
+	return stream
+}
+
+func startsWithVP8LHeaderForSize(payload []byte, width, height int) bool {
+	if len(payload) < lossless.VP8LHeaderSize || payload[0] != lossless.VP8LMagicByte {
+		return false
+	}
+	bits := binary.LittleEndian.Uint32(payload[1:5])
+	w := int(bits&((1<<lossless.VP8LImageSizeBits)-1)) + 1
+	h := int((bits>>lossless.VP8LImageSizeBits)&((1<<lossless.VP8LImageSizeBits)-1)) + 1
+	version := bits >> (2*lossless.VP8LImageSizeBits + 1)
+	return w == width && h == height && version == lossless.VP8LVersion
 }
 
 func TestEncodeLossless_ValidOutput(t *testing.T) {
@@ -407,6 +452,51 @@ func TestEncodeLossy_WithAlpha_Roundtrip(t *testing.T) {
 				}
 				return "outside tolerance"
 			}())
+	}
+}
+
+func TestEncodeLossy_ALPHCompressedPayloadOmitsVP8LHeader(t *testing.T) {
+	const width, height = 64, 64
+	img := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.SetNRGBA(x, y, color.NRGBA{
+				R: 180,
+				G: 90,
+				B: 40,
+				A: byte((x*3 + y*5) & 0xff),
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, img, &EncoderOptions{
+		Quality:          80,
+		Method:           4,
+		AlphaCompression: 1,
+		AlphaFiltering:   0,
+		AlphaQuality:     100,
+	}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	alph, ok := findRIFFChunk(buf.Bytes(), "ALPH")
+	if !ok {
+		t.Fatal("missing ALPH chunk")
+	}
+	if len(alph) < 2 {
+		t.Fatalf("ALPH chunk too small: %d bytes", len(alph))
+	}
+	if got := alph[0] & 0x03; got != 1 {
+		t.Fatalf("alpha compression = %d, want VP8L compression", got)
+	}
+
+	payload := alph[1:]
+	if startsWithVP8LHeaderForSize(payload, width, height) {
+		t.Fatal("compressed ALPH payload contains a VP8L image header")
+	}
+	if _, err := lossless.DecodeVP8L(vp8LStreamForAlphaPayload(payload, width, height)); err != nil {
+		t.Fatalf("ALPH payload is not a valid headerless VP8L stream: %v", err)
 	}
 }
 

--- a/internal/lossy/alpha.go
+++ b/internal/lossy/alpha.go
@@ -1,6 +1,7 @@
 package lossy
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
 
@@ -74,9 +75,10 @@ func DecodeAlpha(data []byte, width, height int) ([]byte, error) {
 
 	case AlphaLosslessCompression:
 		// VP8L-compressed alpha: decode using the lossless decoder.
-		// The alpha data is encoded as a VP8L bitstream where the
-		// green channel contains the alpha values.
-		alphaImage, err := lossless.DecodeVP8L(payload)
+		// ALPH stores a VP8L image stream without the 5-byte VP8L header;
+		// dimensions come from the enclosing canvas. Rebuild the header here
+		// before feeding it to the standalone VP8L decoder.
+		alphaImage, err := lossless.DecodeVP8L(alphaVP8LStream(payload, width, height))
 		if err != nil {
 			return nil, fmt.Errorf("alpha: VP8L decode failed: %w", err)
 		}
@@ -495,21 +497,25 @@ func encodeAlphaInternal(data []byte, width, height, method, filter int,
 		}
 
 		lcfg := &lossless.EncoderConfig{
-			Quality: q,
-			Method:  effortLevel,
+			Quality:             q,
+			Method:              effortLevel,
 			NearLosslessQuality: 100,
 		}
 		compressed, err := lossless.Encode(argb, width, height, lcfg)
 		if err != nil {
 			return nil, 0, fmt.Errorf("alpha: VP8L encode failed: %w", err)
 		}
+		if len(compressed) < lossless.VP8LHeaderSize {
+			return nil, 0, fmt.Errorf("alpha: VP8L encode produced truncated stream")
+		}
+		payload := compressed[lossless.VP8LHeaderSize:]
 
-		if len(compressed) > dataSize {
+		if len(payload) > dataSize {
 			// Compressed is larger than raw — fall back to uncompressed.
 			method = AlphaNoCompression
 			output = alphaSrc
 		} else {
-			output = compressed
+			output = payload
 		}
 	}
 
@@ -528,6 +534,15 @@ func encodeAlphaInternal(data []byte, width, height, method, filter int,
 	copy(result[1:], output)
 
 	return result, len(result), nil
+}
+
+func alphaVP8LStream(payload []byte, width, height int) []byte {
+	stream := make([]byte, lossless.VP8LHeaderSize+len(payload))
+	stream[0] = lossless.VP8LMagicByte
+	bits := uint32(width-1) | uint32(height-1)<<lossless.VP8LImageSizeBits
+	binary.LittleEndian.PutUint32(stream[1:5], bits)
+	copy(stream[lossless.VP8LHeaderSize:], payload)
+	return stream
 }
 
 // applyFiltersAndEncode tries the filter(s) selected by getFilterMap and


### PR DESCRIPTION
## Summary

Fix invalid compressed `ALPH` chunk output for lossy WebP images with transparency.

The encoder was embedding a full VP8L stream, including the 5-byte VP8L image header, inside the `ALPH` chunk payload. For compressed alpha, the WebP format stores a headerless VP8L image stream: decoders reconstruct the VP8L header from the enclosing canvas dimensions before decoding the alpha plane.

This caused strict/libwebp-compatible decoders to reject generated files with errors like:

- `vp8l: invalid color cache parameters`
- `invalid color cache bits`
- `OUT_OF_MEMORY` from `dwebp`

## Changes

- Strip the VP8L header before writing compressed `ALPH` payloads.
- Reconstruct the VP8L header when decoding compressed `ALPH` payloads locally.
- Add a regression test ensuring compressed `ALPH` payloads are headerless and decodable after synthesizing the VP8L header.

## Verification

- `go test ./...`
- Re-ran the issue #4 repro.
- Confirmed the generated WebP now decodes with `golang.org/x/image/webp`.