### PR TITLE
fix(lossless): correct Select predictor logic and add regression tests

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -2241,3 +2241,87 @@ func TestEncode_MalformedNRGBA_FallsToGenericPath(t *testing.T) {
 		t.Fatalf("decoded size = %dx%d, want 4x4", decoded.Bounds().Dx(), decoded.Bounds().Dy())
 	}
 }
+
+// TestEncodeLossless_HighEntropyRoundtrip is a regression test for issue #7
+// (https://github.com/deepteams/webp/issues/7): lossless VP8L encoding of
+// photographic / high-entropy images produced visible block corruption.
+//
+// Root cause: the encoder's Select predictor (mode 11, selectPred in
+// internal/lossless/encode_predictor.go) summed (|top-topLeft| - |left-topLeft|),
+// the negation of the spec / decoder formula (|left-topLeft| - |top-topLeft|).
+// When the per-tile predictor search chose mode 11, the encoder predicted the
+// opposite neighbor from what the decoder reconstructs, so the residuals were
+// uninvertible and whole tiles decoded to garbage (magenta/cyan/green blocks).
+//
+// Lossless must be bit-exact, so this test round-trips noisy images that
+// reliably exercise the Select predictor across several sizes and methods and
+// asserts every pixel survives unchanged.
+func TestEncodeLossless_HighEntropyRoundtrip(t *testing.T) {
+	// Per-channel independent pseudo-noise on top of a smooth gradient: the
+	// gradient makes spatial predictors (including Select) attractive per tile,
+	// while the noise keeps entropy high. Deterministic LCG (no math/rand
+	// dependency) so the corpus is stable across Go versions.
+	makeImg := func(w, h int) *image.NRGBA {
+		img := image.NewNRGBA(image.Rect(0, 0, w, h))
+		var s uint32 = 0x12345678
+		next := func() uint32 { s = s*1664525 + 1013904223; return s }
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				img.SetNRGBA(x, y, color.NRGBA{
+					R: uint8((x*7 + y*3 + int(next()>>24)) & 0xff),
+					G: uint8((x*3 + y*5 + int(next()>>24)) & 0xff),
+					B: uint8((x*11 + y*2 + int(next()>>24)) & 0xff),
+					A: 255,
+				})
+			}
+		}
+		return img
+	}
+
+	sizes := []struct{ w, h int }{{48, 48}, {64, 64}, {127, 65}, {200, 150}}
+	methods := []int{0, 2, 4, 6}
+
+	for _, sz := range sizes {
+		img := makeImg(sz.w, sz.h)
+		for _, method := range methods {
+			t.Run(fmt.Sprintf("%dx%d_m%d", sz.w, sz.h, method), func(t *testing.T) {
+				var buf bytes.Buffer
+				if err := Encode(&buf, img, &EncoderOptions{
+					Lossless: true,
+					Quality:  75,
+					Method:   method,
+				}); err != nil {
+					t.Fatalf("Encode: %v", err)
+				}
+
+				decoded, err := Decode(bytes.NewReader(buf.Bytes()))
+				if err != nil {
+					t.Fatalf("Decode: %v", err)
+				}
+				b := decoded.Bounds()
+				if b.Dx() != sz.w || b.Dy() != sz.h {
+					t.Fatalf("decoded size = %dx%d, want %dx%d", b.Dx(), b.Dy(), sz.w, sz.h)
+				}
+
+				diff := 0
+				var fx, fy int = -1, -1
+				for y := 0; y < sz.h; y++ {
+					for x := 0; x < sz.w; x++ {
+						or, og, ob, oa := img.At(x, y).RGBA()
+						dr, dg, db, da := decoded.At(x, y).RGBA()
+						if or != dr || og != dg || ob != db || oa != da {
+							if diff == 0 {
+								fx, fy = x, y
+							}
+							diff++
+						}
+					}
+				}
+				if diff != 0 {
+					t.Fatalf("lossless round-trip not bit-exact: %d/%d pixels differ (first at %d,%d)",
+						diff, sz.w*sz.h, fx, fy)
+				}
+			})
+		}
+	}
+}

--- a/internal/lossless/encode_predictor.go
+++ b/internal/lossless/encode_predictor.go
@@ -83,7 +83,11 @@ func selectPred(left, top, topLeft uint32) uint32 {
 	if bc3 < 0 {
 		bc3 = -bc3
 	}
-	pa := (ac0 - bc0) + (ac1 - bc1) + (ac2 - bc2) + (ac3 - bc3)
+	// pa_minus_pb = sum of (|left - topLeft| - |top - topLeft|), matching the
+	// decoder's selectPredictor and libwebp's Select. The previous code summed
+	// (ac - bc), i.e. the negation, which inverted the top/left decision and
+	// produced residuals the decoder could not reconstruct (issue #7).
+	pa := (bc0 - ac0) + (bc1 - ac1) + (bc2 - ac2) + (bc3 - ac3)
 	if pa <= 0 {
 		return top
 	}

--- a/internal/lossless/select_predictor_test.go
+++ b/internal/lossless/select_predictor_test.go
@@ -1,0 +1,46 @@
+package lossless
+
+import "testing"
+
+// TestSelectPredictorEncoderMatchesDecoder is a regression test for issue #7.
+//
+// The Select predictor (mode 11) must make the SAME top-vs-left choice in the
+// encoder (selectPred, used to compute forward residuals) and the decoder
+// (selectPredictor, used to reconstruct). The encoder previously summed the
+// negation of the spec formula, inverting the choice for many inputs and
+// corrupting any tile the per-tile search assigned to mode 11.
+//
+// Sweeping a coarse grid over all four ARGB channels of left/top/topLeft gives
+// broad coverage of the sign-of-sum decision boundary; the two functions must
+// agree on every sample.
+func TestSelectPredictorEncoderMatchesDecoder(t *testing.T) {
+	vals := []uint32{0, 1, 7, 64, 127, 128, 200, 254, 255}
+	mismatches := 0
+	for _, lr := range vals {
+		for _, lg := range vals {
+			for _, tr := range vals {
+				for _, tg := range vals {
+					for _, cr := range vals {
+						for _, cg := range vals {
+							left := 0xff000000 | lr<<16 | lg<<8 | lr
+							top := 0xff000000 | tr<<16 | tg<<8 | tg
+							topLeft := 0xff000000 | cr<<16 | cg<<8 | cr
+							if selectPred(left, top, topLeft) != selectPredictor(left, top, topLeft) {
+								if mismatches < 5 {
+									t.Errorf("mismatch: left=%08x top=%08x topLeft=%08x enc=%08x dec=%08x",
+										left, top, topLeft,
+										selectPred(left, top, topLeft),
+										selectPredictor(left, top, topLeft))
+								}
+								mismatches++
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if mismatches != 0 {
+		t.Fatalf("selectPred disagrees with selectPredictor on %d input combinations", mismatches)
+	}
+}


### PR DESCRIPTION
Summary

Fixes #7. Lossless (Options.Lossless = true) encoding could produce visible block corruption (magenta/cyan/green/yellow blocks) on photographic / high-entropy images, while lossy encoding of the same source was fine.

Root cause

The encoder's Select predictor (predictor mode 11, selectPred in internal/lossless/encode_predictor.go) computed:

pa := (ac0 - bc0) + (ac1 - bc1) + (ac2 - bc2) + (ac3 - bc3)

i.e. Σ(|top − topLeft| − |left − topLeft|) — the negation of the spec formula used by the decoder (selectPredictor) and libwebp's Select, which is Σ(|left − topLeft| − |top − topLeft|).

When the per-tile predictor search assigned mode 11 to a tile, the encoder predicted the opposite neighbor (top vs left) from what the decoder reconstructs. The residuals were therefore not invertible, and whole tiles decoded to garbage — hence the block-shaped corruption.

As a side effect, the broken estimate also made mode 11 look expensive, so the encoder usually avoided it. That's why the bug was content-/method-dependent: smooth images at low methods round-tripped fine, while high-entropy content and higher methods (5–6) triggered it.

How it was diagnosed

- Decoding the encoder's output with the reference decoder (golang.org/x/image/webp) produced the same corruption as our own decoder → the bitstream is internally consistent but doesn't represent the source → the bug is on the encode side.
- Round-tripping each forward transform in isolation pinpointed the predictor transform, and a per-mode sweep isolated mode 11 (Select).
- Verified on the actual issue image: at v1.2.3, Method 5–6 reproduce the corruption without the fix (maxDelta=240, 3376 corrupted pixels) and are bit-exact with it. All methods produce smaller files after the fix (e.g. method 4: 2,418,568 vs 2,450,230 bytes), since the Select predictor can now be used correctly.

The fix

One line in internal/lossless/encode_predictor.go, bringing selectPred in line with the decoder and libwebp:

pa := (bc0 - ac0) + (bc1 - ac1) + (bc2 - ac2) + (bc3 - ac3)

Tests

Both fail without the fix, pass with it:

- TestEncodeLossless_HighEntropyRoundtrip — asserts bit-exact lossless round-trips across several sizes (including odd dimensions) and methods 0/2/4/6.
- TestSelectPredictorEncoderMatchesDecoder — locks the invariant that the encoder's selectPred agrees with the decoder's selectPredictor across a sweep of ARGB inputs.

go build ./... and go test ./... are green.