### PR TITLE
fix(dsp): guard gamma table init with sync.Once for concurrent encode

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -418,6 +418,9 @@ func resolveAlphaQuality(v int) int {
 // Encode writes the image img to w in WebP format.
 // If opts is nil, DefaultOptions() is used.
 // Returns an error if opts contains invalid parameter values.
+//
+// Encode is safe for concurrent use and deterministic: the output bytes
+// depend only on img and opts.
 func Encode(w io.Writer, img image.Image, opts *EncoderOptions) error {
 	if w == nil {
 		return fmt.Errorf("webp: nil writer")

--- a/internal/dsp/yuv.go
+++ b/internal/dsp/yuv.go
@@ -1,6 +1,9 @@
 package dsp
 
-import "math"
+import (
+	"math"
+	"sync"
+)
 
 // BT.601 YUV <-> RGB conversion using fixed-point arithmetic.
 // All coefficients match libwebp yuv.h exactly.
@@ -182,36 +185,33 @@ const (
 var (
 	kLinearToGammaTab [kGammaTabSize + 2]uint32 // [0..GAMMA_TAB_SIZE+1] = [0..33]
 	kGammaToLinearTab [256]uint32
-	gammaTablesInited bool
+	gammaTablesOnce   sync.Once
 )
 
 // InitGammaTables initializes the gamma correction lookup tables.
-// Safe to call multiple times; only initializes once.
+// Safe to call concurrently from multiple goroutines; tables are initialized exactly once.
 func InitGammaTables() {
-	if gammaTablesInited {
-		return
-	}
-	gammaTablesInited = true
+	gammaTablesOnce.Do(func() {
+		// kGammaToLinearTab: maps gamma-space [0..255] to linear fixed-point.
+		// C reference (yuv.c:243-244): pow(norm * v, kGamma) * kGammaScale
+		// where kGamma = 0.80, norm = 1/255.
+		for i := 0; i < 256; i++ {
+			v := float64(i) / 255.0
+			lin := gammaPow(v, kGamma) * float64(kGammaScale)
+			kGammaToLinearTab[i] = uint32(lin + 0.5)
+		}
 
-	// kGammaToLinearTab: maps gamma-space [0..255] to linear fixed-point.
-	// C reference (yuv.c:243-244): pow(norm * v, kGamma) * kGammaScale
-	// where kGamma = 0.80, norm = 1/255.
-	for i := 0; i < 256; i++ {
-		v := float64(i) / 255.0
-		lin := gammaPow(v, kGamma) * float64(kGammaScale)
-		kGammaToLinearTab[i] = uint32(lin + 0.5)
-	}
-
-	// kLinearToGammaTab: maps linear fixed-point [0..kGammaTabSize] to gamma [0..255].
-	// C reference (yuv.c:246-247): 255 * pow(scale * v, 1/kGamma)
-	// where scale = kGammaTabScale / kGammaScale.
-	scale := float64(kGammaTabScale) / float64(kGammaScale)
-	for i := 0; i <= kGammaTabSize; i++ {
-		v := scale * float64(i)
-		g := gammaPow(v, 1.0/kGamma) * 255.0
-		kLinearToGammaTab[i] = uint32(g + 0.5)
-	}
-	kLinearToGammaTab[kGammaTabSize+1] = 255
+		// kLinearToGammaTab: maps linear fixed-point [0..kGammaTabSize] to gamma [0..255].
+		// C reference (yuv.c:246-247): 255 * pow(scale * v, 1/kGamma)
+		// where scale = kGammaTabScale / kGammaScale.
+		scale := float64(kGammaTabScale) / float64(kGammaScale)
+		for i := 0; i <= kGammaTabSize; i++ {
+			v := scale * float64(i)
+			g := gammaPow(v, 1.0/kGamma) * 255.0
+			kLinearToGammaTab[i] = uint32(g + 0.5)
+		}
+		kLinearToGammaTab[kGammaTabSize+1] = 255
+	})
 }
 
 // gammaPow computes base^exp for gamma correction.

--- a/internal/lossy/encode.go
+++ b/internal/lossy/encode.go
@@ -18,7 +18,6 @@ type importUVWorker struct {
 	tmpRGB                 []uint16
 }
 
-
 var importUVWorkerPool sync.Pool
 
 func getImportUVWorker(padW, uvWidth int) *importUVWorker {
@@ -45,22 +44,22 @@ func getImportUVWorker(padW, uvWidth int) *importUVWorker {
 
 // EncodeConfig holds VP8 encoding parameters.
 type EncodeConfig struct {
-	Quality    int  // 0-100, maps to quantizer.
-	TargetSize int  // Target byte size (0 = use quality).
-	TargetPSNR float32 // Target PSNR (0 = disabled). Matches C libwebp's target_PSNR.
-	Method     int  // 0-6, compression effort.
-	SNSStrength int // 0-100, spatial noise shaping.
-	FilterStrength int // 0-100, deblocking filter.
-	FilterSharpness int // 0-7, filter sharpness.
-	FilterType int  // 0=simple, 1=strong loop-filter.
-	Partitions int  // 0-3 => 1, 2, 4, 8 partitions.
-	Segments   int  // 1-4, number of segments.
-	Pass       int  // 1-10, multi-pass encoding.
-	Preprocessing int  // Bitmask: bit 0 = segment smooth, bit 1 = dithering.
-	Dithering  float32 // Dithering amplitude [0..1] for RGB->YUV conversion.
-	QMin       int  // 0-100, minimum quantizer value. Matches C libwebp's qmin.
-	QMax       int  // 0-100, maximum quantizer value. Matches C libwebp's qmax. -1 = use default (100).
-	HasAlpha   int  // -1 = unknown (will scan), 0 = no alpha, 1 = has alpha. Avoids redundant imageHasAlpha scans.
+	Quality         int     // 0-100, maps to quantizer.
+	TargetSize      int     // Target byte size (0 = use quality).
+	TargetPSNR      float32 // Target PSNR (0 = disabled). Matches C libwebp's target_PSNR.
+	Method          int     // 0-6, compression effort.
+	SNSStrength     int     // 0-100, spatial noise shaping.
+	FilterStrength  int     // 0-100, deblocking filter.
+	FilterSharpness int     // 0-7, filter sharpness.
+	FilterType      int     // 0=simple, 1=strong loop-filter.
+	Partitions      int     // 0-3 => 1, 2, 4, 8 partitions.
+	Segments        int     // 1-4, number of segments.
+	Pass            int     // 1-10, multi-pass encoding.
+	Preprocessing   int     // Bitmask: bit 0 = segment smooth, bit 1 = dithering.
+	Dithering       float32 // Dithering amplitude [0..1] for RGB->YUV conversion.
+	QMin            int     // 0-100, minimum quantizer value. Matches C libwebp's qmin.
+	QMax            int     // 0-100, maximum quantizer value. Matches C libwebp's qmax. -1 = use default (100).
+	HasAlpha        int     // -1 = unknown (will scan), 0 = no alpha, 1 = has alpha. Avoids redundant imageHasAlpha scans.
 }
 
 // DefaultConfig returns sensible encoding defaults (quality 75, method 4).
@@ -103,20 +102,20 @@ type VP8Encoder struct {
 	savedY, savedU, savedV []byte
 
 	// Reconstruction buffers (BPS-strided, for prediction/comparison).
-	yuvIn  []byte // original (source) macroblock, BPS-strided
-	yuvOut []byte // best reconstructed output, BPS-strided
+	yuvIn   []byte // original (source) macroblock, BPS-strided
+	yuvOut  []byte // best reconstructed output, BPS-strided
 	yuvOut2 []byte // secondary reconstruction buffer, BPS-strided
-	yuvP   []byte // prediction buffer, BPS-strided (33*BPS for top+left context)
+	yuvP    []byte // prediction buffer, BPS-strided (33*BPS for top+left context)
 
 	// Per-macroblock info.
 	mbInfo []MBEncInfo
 
 	// Segment info.
-	dqm  [NumMBSegments]SegmentInfo
+	dqm        [NumMBSegments]SegmentInfo
 	segmentHdr SegmentHeader
 
 	// Probabilities.
-	proba  Proba
+	proba Proba
 
 	// Token buffers (partition 0 = modes, partition 1+ = coefficients).
 	tokens TokenBuffer
@@ -135,10 +134,10 @@ type VP8Encoder struct {
 	numParts int
 
 	// NZ context tracking for token encoding (mirrors decoder's parseResiduals).
-	topNz   []uint32 // per-column top NZ bits
-	leftNz  uint32   // left NZ bits for current row
-	topNzDC []uint8  // per-column top DC NZ (for I16 mode)
-	leftNzDC uint8   // left DC NZ for current row
+	topNz    []uint32 // per-column top NZ bits
+	leftNz   uint32   // left NZ bits for current row
+	topNzDC  []uint8  // per-column top DC NZ (for I16 mode)
+	leftNzDC uint8    // left DC NZ for current row
 
 	// Quantization deltas (applied to base q for each channel).
 	// Y1 DC delta (always 0 in C libwebp; included for structural parity).
@@ -233,23 +232,23 @@ type VP8Encoder struct {
 
 	// Pre-allocated serial UV conversion buffers (dithered/non-NRGBA path).
 	// Reused via the encoder pool when dimensions match.
-	serialRowR, serialRowG, serialRowB, serialRowA [2][]uint8
+	serialRowR, serialRowG, serialRowB, serialRowA             [2][]uint8
 	serialPlanarR, serialPlanarG, serialPlanarB, serialPlanarA []uint8
-	serialTmpRGB []uint16
+	serialTmpRGB                                               []uint16
 }
 
 // MBEncInfo stores per-macroblock encoding decisions.
 type MBEncInfo struct {
-	MBType   int // 0=i16, 1=i4
-	UVMode   uint8
-	Segment  uint8
-	Alpha    int // complexity alpha from analysis (0-255), used for segment assignment
-	Skip     bool
+	MBType  int // 0=i16, 1=i4
+	UVMode  uint8
+	Segment uint8
+	Alpha   int // complexity alpha from analysis (0-255), used for segment assignment
+	Skip    bool
 	// Intra prediction modes.
-	I16Mode  uint8
-	Modes    [16]uint8 // 4x4 modes when MBType==1
+	I16Mode uint8
+	Modes   [16]uint8 // 4x4 modes when MBType==1
 	// Quantized coefficients: 16 Y blocks (0-255) + 4 U (256-319) + 4 V (320-383) + 1 WHT DC (384-399).
-	Coeffs   [400]int16
+	Coeffs [400]int16
 	// Non-zero flags.
 	NonZeroY  uint32
 	NonZeroUV uint32
@@ -278,9 +277,9 @@ type MBEncInfo struct {
 // SegmentInfo holds quantization parameters for one segment.
 type SegmentInfo struct {
 	// Quant matrices for this segment.
-	Y1  SegmentQuant // luma
-	Y2  SegmentQuant // luma DC (secondary transform)
-	UV  SegmentQuant // chroma
+	Y1 SegmentQuant // luma
+	Y2 SegmentQuant // luma DC (secondary transform)
+	UV SegmentQuant // chroma
 	// Lambda for RD scoring (mode selection).
 	Lambda     int // general lambda (for backward compat)
 	LambdaI4   int // I4x4 mode selection lambda
@@ -296,14 +295,14 @@ type SegmentInfo struct {
 	Lambda2    int // squared lambda
 	MinDisto   int // minimum distortion
 	// Global quantizer value.
-	Quant      int
-	FStrength  int // filter strength for this segment
+	Quant     int
+	FStrength int // filter strength for this segment
 	// I4 vs I16 penalty.
-	I4Penalty  int // cost penalty for choosing I4 over I16 mode
+	I4Penalty int // cost penalty for choosing I4 over I16 mode
 	// For SNS.
-	Alpha      int // segment susceptibility [-127..127], from SetSegmentAlphas
-	Beta       int
-	MaxEdge    int
+	Alpha   int // segment susceptibility [-127..127], from SetSegmentAlphas
+	Beta    int
+	MaxEdge int
 }
 
 // SegmentQuant holds quantizer/dequantizer values and bias for one component.
@@ -311,21 +310,21 @@ type SegmentInfo struct {
 // Quantization uses QFIX=17 fixed-point: level = (coeff * IQuant + Bias) >> 17.
 type SegmentQuant struct {
 	// AC quantizer (coefficients 1-15).
-	Quant    int    // AC quantizer multiplier (dequantization factor)
-	IQuant   int    // AC inverse quantizer multiplier (Q17 fixed-point)
-	Bias     int    // AC rounding bias for QUANTDIV
-	Zthresh  int    // AC zero threshold
+	Quant   int // AC quantizer multiplier (dequantization factor)
+	IQuant  int // AC inverse quantizer multiplier (Q17 fixed-point)
+	Bias    int // AC rounding bias for QUANTDIV
+	Zthresh int // AC zero threshold
 	// DC quantizer (coefficient 0).
-	DCQuant  int    // DC quantizer multiplier (dequantization factor)
-	DCIQuant int    // DC inverse quantizer multiplier (Q17 fixed-point)
-	DCBias   int    // DC rounding bias for QUANTDIV
-	DCZthresh int   // DC zero threshold
-	Sharpen  [16]int16 // sharpening values added to coefficients before quantization
+	DCQuant   int       // DC quantizer multiplier (dequantization factor)
+	DCIQuant  int       // DC inverse quantizer multiplier (Q17 fixed-point)
+	DCBias    int       // DC rounding bias for QUANTDIV
+	DCZthresh int       // DC zero threshold
+	Sharpen   [16]int16 // sharpening values added to coefficients before quantization
 }
 
 // EncStats collects encoding statistics for multi-pass optimization.
 type EncStats struct {
-	PSNR      [5]float64 // per-channel + global
+	PSNR       [5]float64 // per-channel + global
 	CodedSize  int
 	HeaderSize int
 	Residuals  int
@@ -386,6 +385,9 @@ func ReleaseEncoder(enc *VP8Encoder) {
 
 // resetForReuse clears mutable state so a pooled encoder can be reused.
 // The caller must have verified that mbW and mbH match.
+//
+// Any field read by the encode path before being fully rewritten leaks
+// prior-encode bytes into the bitstream under pool reuse.
 func (enc *VP8Encoder) resetForReuse(cfg EncodeConfig, width, height int) {
 	enc.config = cfg
 	enc.width = width
@@ -426,6 +428,12 @@ func (enc *VP8Encoder) resetForReuse(cfg EncodeConfig, width, height int) {
 	enc.savedU = nil
 	enc.savedV = nil
 	enc.tmpBestNz = 0
+
+	// MBEncInfo has read-before-write paths (e.g. NzDC is only set on the
+	// I16 residual branch); reset the whole slab to avoid tracking each one.
+	for i := range enc.mbInfo {
+		enc.mbInfo[i] = MBEncInfo{}
+	}
 
 	// Clear topDerr (already allocated).
 	for i := range enc.topDerr {
@@ -1423,13 +1431,13 @@ func (enc *VP8Encoder) statLoop() {
 // Supports convergence on either target size or target PSNR,
 // controlled by the doSizeSearch flag.
 type passStats struct {
-	isFirst                bool
-	dq                     float64
-	q, lastQ               float64
-	qmin, qmax             float64
-	value, lastValue       float64 // PSNR or size (depending on doSizeSearch)
-	target                 float64 // target size or PSNR
-	doSizeSearch           bool    // true=converge on size, false=converge on PSNR
+	isFirst          bool
+	dq               float64
+	q, lastQ         float64
+	qmin, qmax       float64
+	value, lastValue float64 // PSNR or size (depending on doSizeSearch)
+	target           float64 // target size or PSNR
+	doSizeSearch     bool    // true=converge on size, false=converge on PSNR
 }
 
 // initPassStats initializes rate control state, matching C libwebp's

--- a/internal/lossy/encode.go
+++ b/internal/lossy/encode.go
@@ -1125,8 +1125,11 @@ func setupSegment(enc *VP8Encoder, idx, q int) {
 	// Texture distortion lambda (for perceptual SD term in mode selection).
 	// In libwebp: tlambda = (tlambda_scale * q_i4) >> 5
 	// tlambda_scale = sns_strength (0-100) for method >= 4, else 0.
+	// Assign in both branches: dqm is pool-reused.
 	if enc.config.Method >= 4 && enc.config.SNSStrength > 0 {
 		seg.TLambdaSD = (enc.config.SNSStrength * qI4) >> 5
+	} else {
+		seg.TLambdaSD = 0
 	}
 
 	// MinDisto: quantization-aware minimum distortion threshold (matching libwebp).

--- a/internal/lossy/encode.go
+++ b/internal/lossy/encode.go
@@ -435,6 +435,13 @@ func (enc *VP8Encoder) resetForReuse(cfg EncodeConfig, width, height int) {
 		enc.mbInfo[i] = MBEncInfo{}
 	}
 
+	// dqm SegmentInfo has the same class of read-before-write leak under pool
+	// reuse (e.g. TLambdaSD is only set on the SNS path). Reset every segment
+	// rather than tracking individual conditionally-written fields.
+	for i := range enc.dqm {
+		enc.dqm[i] = SegmentInfo{}
+	}
+
 	// Clear topDerr (already allocated).
 	for i := range enc.topDerr {
 		enc.topDerr[i] = [2][2]int8{}

--- a/race_test.go
+++ b/race_test.go
@@ -72,6 +72,68 @@ func TestConcurrentEncodeDeterminism(t *testing.T) {
 	}
 }
 
+// noisyImage builds an image with enough high-frequency content to make the
+// SNS texture-distortion term tip mode decisions. A smooth gradient is too
+// uniform to surface the leak.
+func noisyImage(w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x*7 + y*3) & 0xFF),
+				G: uint8((x*5 ^ y*11) & 0xFF),
+				B: uint8((x ^ (y << 2)) & 0xFF),
+				A: 255,
+			})
+		}
+	}
+	return img
+}
+
+// TestEncodePoolStateAcrossOpts verifies that the encoder pool does not leak
+// dqm SegmentInfo state across encodes at the same dimensions with different
+// opts. setupSegment's TLambdaSD write is gated on Method>=4 && SNSStrength>0;
+// without an else branch zeroing it, an encode with SNSStrength=0 after one
+// with SNSStrength=50 inherits the prior value via pool reuse.
+func TestEncodePoolStateAcrossOpts(t *testing.T) {
+	img := noisyImage(256, 256)
+	optsOff := &webp.EncoderOptions{Quality: 80, Method: 4, SNSStrength: 0}
+	optsOn := &webp.EncoderOptions{Quality: 80, Method: 4, SNSStrength: 50}
+
+	// Warm the pool so the baseline measures the steady-state pooled encode.
+	for i := 0; i < 3; i++ {
+		var b bytes.Buffer
+		if err := webp.Encode(&b, img, optsOff); err != nil {
+			t.Fatalf("warm-up encode: %v", err)
+		}
+	}
+
+	var baseline bytes.Buffer
+	if err := webp.Encode(&baseline, img, optsOff); err != nil {
+		t.Fatalf("baseline encode: %v", err)
+	}
+
+	// Prime the pool with opts that set TLambdaSD > 0.
+	for i := 0; i < 3; i++ {
+		var b bytes.Buffer
+		if err := webp.Encode(&b, img, optsOn); err != nil {
+			t.Fatalf("primer encode: %v", err)
+		}
+	}
+
+	// Encode optsOff again. With the fix, every byte matches baseline;
+	// without it, a positive TLambdaSD from the primer survives.
+	for i := 0; i < 5; i++ {
+		var b bytes.Buffer
+		if err := webp.Encode(&b, img, optsOff); err != nil {
+			t.Fatalf("post-primer encode #%d: %v", i, err)
+		}
+		if !bytes.Equal(b.Bytes(), baseline.Bytes()) {
+			t.Fatalf("encode #%d: dqm state leaked from prior SNSStrength=50 encode (baseline=%d bytes, got=%d bytes)", i, baseline.Len(), b.Len())
+		}
+	}
+}
+
 func TestConcurrentEncodeRace(t *testing.T) {
 	img := gradient(256, 256, 0)
 

--- a/race_test.go
+++ b/race_test.go
@@ -12,8 +12,68 @@ import (
 	"github.com/deepteams/webp"
 )
 
+func gradient(w, h, seed int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x + seed) & 0xFF),
+				G: uint8((y + seed) & 0xFF),
+				B: 128,
+				A: 255,
+			})
+		}
+	}
+	return img
+}
+
+// TestConcurrentEncodeDeterminism encodes image A while goroutines hammer the
+// shared encoder pool with image B at matching dimensions, then checks every
+// image-A encode is byte-identical to a canonical reference.
+func TestConcurrentEncodeDeterminism(t *testing.T) {
+	imgA := gradient(640, 480, 0)
+	imgB := gradient(640, 480, 1)
+	opts := &webp.EncoderOptions{Quality: 80}
+
+	var canonical bytes.Buffer
+	if err := webp.Encode(&canonical, imgA, opts); err != nil {
+		t.Fatalf("canonical encode: %v", err)
+	}
+
+	const iterations = 50
+	const noisemakers = 16
+	fail := 0
+
+	for i := 0; i < iterations; i++ {
+		var wg sync.WaitGroup
+		wg.Add(noisemakers)
+		for j := 0; j < noisemakers; j++ {
+			go func() {
+				defer wg.Done()
+				_ = webp.Encode(io.Discard, imgB, opts)
+			}()
+		}
+
+		var buf bytes.Buffer
+		if err := webp.Encode(&buf, imgA, opts); err != nil {
+			t.Errorf("iter %d: encode A err = %v", i, err)
+			wg.Wait()
+			continue
+		}
+		wg.Wait()
+
+		if !bytes.Equal(buf.Bytes(), canonical.Bytes()) {
+			fail++
+		}
+	}
+
+	if fail != 0 {
+		t.Fatalf("%d/%d iterations produced non-canonical bytes; pool state is leaking across encodes", fail, iterations)
+	}
+}
+
 func TestConcurrentEncodeRace(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 256, 256))
+	img := gradient(256, 256, 0)
 
 	const n = 16
 	var wg sync.WaitGroup
@@ -28,12 +88,7 @@ func TestConcurrentEncodeRace(t *testing.T) {
 }
 
 func TestConcurrentEncodeLosslessRace(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
-	for y := 0; y < 64; y++ {
-		for x := 0; x < 64; x++ {
-			img.Set(x, y, color.RGBA{uint8(x), uint8(y), 0, 255})
-		}
-	}
+	img := gradient(64, 64, 0)
 
 	const n = 16
 	var wg sync.WaitGroup
@@ -74,12 +129,7 @@ func TestConcurrentDecodeRace(t *testing.T) {
 }
 
 func TestConcurrentEncodeDecodeRace(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 128, 128))
-	for y := 0; y < 128; y++ {
-		for x := 0; x < 128; x++ {
-			img.Set(x, y, color.RGBA{uint8(x ^ y), uint8(x), uint8(y), 255})
-		}
-	}
+	img := gradient(128, 128, 0)
 
 	const n = 16
 	var wg sync.WaitGroup

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,101 @@
+package webp_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/deepteams/webp"
+)
+
+func TestConcurrentEncodeRace(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 256, 256))
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_ = webp.Encode(io.Discard, img, &webp.EncoderOptions{Quality: 80})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentEncodeLosslessRace(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for y := 0; y < 64; y++ {
+		for x := 0; x < 64; x++ {
+			img.Set(x, y, color.RGBA{uint8(x), uint8(y), 0, 255})
+		}
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_ = webp.Encode(io.Discard, img, &webp.EncoderOptions{Lossless: true})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentDecodeRace(t *testing.T) {
+	lossy, err := os.ReadFile("testdata/blue_16x16_lossy.webp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lossless, err := os.ReadFile("testdata/red_4x4_lossless.webp")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_, _ = webp.Decode(bytes.NewReader(lossy))
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = webp.Decode(bytes.NewReader(lossless))
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentEncodeDecodeRace(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 128, 128))
+	for y := 0; y < 128; y++ {
+		for x := 0; x < 128; x++ {
+			img.Set(x, y, color.RGBA{uint8(x ^ y), uint8(x), uint8(y), 255})
+		}
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			if err := webp.Encode(&buf, img, &webp.EncoderOptions{Quality: 75}); err != nil {
+				t.Errorf("encode: %v", err)
+				return
+			}
+			if _, err := webp.Decode(&buf); err != nil {
+				t.Errorf("decode: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- Add `sync.Once` to `dsp.InitGammaTables` so concurrent first encodes  don't trip `-race`.
- Reset `mbInfo` in `VP8Encoder.resetForReuse` so a pooled encoder produces  byte-identical output for a given input regardless of what was encoded  before. Without this, fields that are only written on one branch (e.g. `NzDC` on the I16 residual path) leak prior-encode bytes into the new  bitstream.
- Add comment that concurrency works on `webp.Encode`.
- Also set seg.TLambdaSD = 0 when (Method >= 4 && SSNSStrength>0). Verified to fail without it. 

## Tested
- `go test -race ./...`
- New `TestConcurrentEncodeDeterminism` reproducer (50 iters, 16 noise goroutines) passes 20× consecutively
- Existing race tests refactored onto a shared `gradient` fixture. Slightly better coverage?
- New `TestEncodePoolStateAcrossOpts` that tests using noisy image
