### PR TITLE
Fix 32 bit overflow

### DIFF
--- a/internal/dsp/random.go
+++ b/internal/dsp/random.go
@@ -52,11 +52,13 @@ func InitRandom(rg *VP8Random, dithering float32) {
 // RandomBits2 returns a centered pseudo-random number with numBits amplitude,
 // scaled by the given amp. Matches C VP8RandomBits2.
 func RandomBits2(rg *VP8Random, numBits, amp int) int {
-	diff := int(rg.tab[rg.index1]) - int(rg.tab[rg.index2])
-	if diff < 0 {
-		diff += 1 << 31
+	// Use uint32 arithmetic so that the constant 1<<31 (2147483648) never
+	// overflows int on 32-bit targets (GOARCH=386, arm).
+	tab := rg.tab[rg.index1] - rg.tab[rg.index2]
+	if int32(tab) < 0 {
+		tab += 1 << 31
 	}
-	rg.tab[rg.index1] = uint32(diff)
+	rg.tab[rg.index1] = tab
 	rg.index1++
 	if rg.index1 == vp8RandomTableSize {
 		rg.index1 = 0
@@ -66,7 +68,7 @@ func RandomBits2(rg *VP8Random, numBits, amp int) int {
 		rg.index2 = 0
 	}
 	// sign-extend, 0-center
-	diff = int(int32(uint32(diff)<<1)) >> (32 - numBits)
+	diff := int(int32(tab<<1)) >> (32 - numBits)
 	diff = (diff * amp) >> vp8RandomDitherFix // restrict range
 	diff += 1 << (numBits - 1)               // shift back to 0.5-center
 	return diff

--- a/internal/dsp/random.go
+++ b/internal/dsp/random.go
@@ -52,12 +52,9 @@ func InitRandom(rg *VP8Random, dithering float32) {
 // RandomBits2 returns a centered pseudo-random number with numBits amplitude,
 // scaled by the given amp. Matches C VP8RandomBits2.
 func RandomBits2(rg *VP8Random, numBits, amp int) int {
-	// Use uint32 arithmetic so that the constant 1<<31 (2147483648) never
-	// overflows int on 32-bit targets (GOARCH=386, arm).
-	tab := rg.tab[rg.index1] - rg.tab[rg.index2]
-	if int32(tab) < 0 {
-		tab += 1 << 31
-	}
+	// Mask to 31 bits: equivalent to the signed "if diff<0 { diff+=1<<31 }" in
+	// the C reference, but avoids overflow on 32-bit targets (GOARCH=386, arm).
+	tab := (rg.tab[rg.index1] - rg.tab[rg.index2]) & 0x7fffffff
 	rg.tab[rg.index1] = tab
 	rg.index1++
 	if rg.index1 == vp8RandomTableSize {

--- a/internal/dsp/random_test.go
+++ b/internal/dsp/random_test.go
@@ -130,3 +130,29 @@ func TestVP8RandomBitsWraparound(t *testing.T) {
 	}
 	// If we got here without panicking, indices wrapped correctly.
 }
+
+func TestVP8RandomTableStays31Bit(t *testing.T) {
+	// tab[0]=0x0de15230 < tab[31]=0x26d7cb1c in the initial table, so the
+	// very first call exercises the negative-diff path (the overflow fix).
+	// After the update tab[0] must still be a 31-bit value (bit 31 clear).
+	var rg VP8Random
+	InitRandom(&rg, 1.0)
+	RandomBits(&rg, 16)
+	if rg.tab[0]&(1<<31) != 0 {
+		t.Errorf("tab[0] = 0x%08x has bit 31 set after negative-diff update", rg.tab[0])
+	}
+}
+
+func TestVP8RandomBitsGolden(t *testing.T) {
+	// Exact output sequence for dithering=1.0, numBits=16.
+	// Guards against any change to the PRNG update step, including the
+	// 32-bit overflow fix (the & 0x7fffffff mask in RandomBits2).
+	want := []int{19987, 42957, 5448, 52772, 34853, 24576, 16, 53171, 8636, 35649}
+	var rg VP8Random
+	InitRandom(&rg, 1.0)
+	for i, w := range want {
+		if got := RandomBits(&rg, 16); got != w {
+			t.Errorf("call %d: got %d, want %d", i, got, w)
+		}
+	}
+}


### PR DESCRIPTION
`RandomBits2` in [internal/dsp/random.go](internal/dsp/random.go) computed the PRNG table update using `int`:

```
diff := int(rg.tab[rg.index1]) - int(rg.tab[rg.index2])
if diff < 0 {
    diff += 1 << 31  // 2147483648
}
```

On 64-bit targets this is fine — `int` is 64 bits and `1 << 31` fits. On 32-bit targets (GOARCH=386, arm), `int` is 32 bits and the constant `1 << 31 (2147483648)` exceeds `math.MaxInt32 (2147483647),` causing a compile-time overflow error.

## The Fix
The table entries are 31-bit values by design (all seeds in `kRandomTable` have bit 31 clear). The conditional `add += 1<<31` is equivalent to masking off bit 31, so the entire `if` block collapses to a single `uint32` mask:

`tab := (rg.tab[rg.index1] - rg.tab[rg.index2]) & 0x7fffffff`

* Subtraction stays in `uint32` throughout — no overflow concern on any platform.
* `& 0x7fffffff` unconditionally clears bit 31, producing the same result as the conditional add in both the positive and negative cases.
* The existing cast chain `int(int32(tab<<1)) >> (32 - numBits)` below it is unchanged and already handles sign extension correctly.

## Tests Added
Two tests in [internal/dsp/random_test.go](internal/dsp/random_test.go):

* `TestVP8RandomTableStays31Bit `— exercises the negative-diff path directly (the initial table state guarantees `tab[0] < tab[31]` on the first call) and asserts the updated table entry has bit 31 clear.
* `TestVP8RandomBitsGolden` — pins the exact 10-value output sequence, catching any future regression in the update step.