### PR TITLE
Optimize reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,27 +224,27 @@ Benchmarked on Apple M5 Max (arm64), 1536x1024 RGB image, Go 1.24.2. Median of 1
 
 | Library | Mode | Time | MB/s | B/op | Allocs |
 |---------|------|-----:|-----:|------:|-------:|
-| **deepteams/webp** (Pure Go) | Lossy | **47.2 ms** | 4.1 | 1.2 MB | 174 |
-| gen2brain/webp (WASM) | Lossy | 54.9 ms | 4.6 | 13 KB | 12 |
-| chai2010/webp (CGo) | Lossy | 73.2 ms | 2.9 | 222 KB | 4 |
-| **deepteams/webp** (Pure Go) | Lossless | **114 ms** | 16.1 | 20.1 MB | 1,177 |
-| gen2brain/webp (WASM) | Lossless | 180 ms | 11.4 | 335 KB | 12 |
-| nativewebp (Pure Go) | Lossless | 272 ms | 7.4 | 85 MB | 2,155 |
-| chai2010/webp (CGo) | Lossless | 899 ms | 1.9 | 2.5 MB | 4 |
+| **deepteams/webp** (Pure Go) | Lossy | **47.8 ms** | 4.0 | 1.2 MB | 166 |
+| gen2brain/webp (WASM) | Lossy | 56.9 ms | 4.4 | 13 KB | 12 |
+| chai2010/webp (CGo) | Lossy | 76.4 ms | 2.7 | 222 KB | 4 |
+| **deepteams/webp** (Pure Go) | Lossless | **116 ms** | 15.8 | 20.1 MB | 1,177 |
+| gen2brain/webp (WASM) | Lossless | 187 ms | 11.0 | 335 KB | 12 |
+| nativewebp (Pure Go) | Lossless | 280 ms | 7.2 | 85 MB | 2,155 |
+| chai2010/webp (CGo) | Lossless | 929 ms | 1.9 | 2.5 MB | 4 |
 
 ### Decode (1536x1024)
 
 | Library | Mode | Time | MB/s | B/op | Allocs |
 |---------|------|-----:|-----:|------:|-------:|
-| **deepteams/webp** (Pure Go) | Lossy | **9.0 ms** | 21.4 | 2.5 MB | 7 |
-| chai2010/webp (CGo) | Lossy | 9.4 ms | 22.4 | 6.4 MB | 23 |
-| golang.org/x/image/webp | Lossy | 17.8 ms | 10.8 | 2.5 MB | 13 |
-| gen2brain/webp (WASM) | Lossy | 21.9 ms | 11.6 | 608 KB | 40 |
-| chai2010/webp (CGo) | Lossless | **19.5 ms** | 91.5 | 10.2 MB | 30 |
-| **deepteams/webp** (Pure Go) | Lossless | **20.0 ms** | 91.3 | 7.9 MB | 226 |
-| gen2brain/webp (WASM) | Lossless | 34.3 ms | 60.2 | 4.4 MB | 46 |
-| nativewebp (Pure Go) | Lossless | 36.7 ms | 54.9 | 6.1 MB | 50 |
-| golang.org/x/image/webp | Lossless | 39.4 ms | 45.2 | 6.8 MB | 966 |
+| **deepteams/webp** (Pure Go) | Lossy | **9.3 ms** | 20.7 | 2.5 MB | 7 |
+| chai2010/webp (CGo) | Lossy | 9.6 ms | 21.8 | 6.4 MB | 23 |
+| golang.org/x/image/webp | Lossy | 18.4 ms | 10.5 | 2.5 MB | 13 |
+| gen2brain/webp (WASM) | Lossy | 22.2 ms | 11.4 | 608 KB | 40 |
+| **deepteams/webp** (Pure Go) | Lossless | **17.0 ms** | 107.3 | 8.3 MB | 225 |
+| chai2010/webp (CGo) | Lossless | 19.2 ms | 91.3 | 10.2 MB | 30 |
+| gen2brain/webp (WASM) | Lossless | 34.0 ms | 60.4 | 4.4 MB | 46 |
+| nativewebp (Pure Go) | Lossless | 35.6 ms | 56.5 | 6.1 MB | 50 |
+| golang.org/x/image/webp | Lossless | 38.7 ms | 47.3 | 6.8 MB | 966 |
 
 In a decode loop, [`DecodeReuse`](#decode-in-a-loop-zero-allocation) drops per-decode allocations from megabytes to a few KB (see `BenchmarkDecodeLossyReuse` / `BenchmarkDecodeLosslessReuse`).
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,39 +22,37 @@ All values are **medians of 10 runs** (`-count=10`). Provides more reliable stat
 
 | Library | Time (ms) | MB/s | B/op | Allocs |
 |---------|----------:|-----:|-----:|-------:|
-| **deepteams/webp** (Pure Go) | **47.2** | 4.1 | 1.2 MB | 174 |
-| gen2brain/webp (WASM) | 54.9 | 4.6 | 13 KB | 12 |
-| chai2010/webp (CGo) | 73.2 | 2.9 | 222 KB | 4 |
+| **deepteams/webp** (Pure Go) | **47.8** | 4.0 | 1.2 MB | 166 |
+| gen2brain/webp (WASM) | 56.9 | 4.4 | 13 KB | 12 |
+| chai2010/webp (CGo) | 76.4 | 2.7 | 222 KB | 4 |
 
 ### Encode Lossless (1536x1024)
 
 | Library | Time (ms) | MB/s | B/op | Allocs |
 |---------|----------:|-----:|------:|-------:|
-| **deepteams/webp** (Pure Go) | **114** | 16.1 | 20.1 MB | 1,177 |
-| gen2brain/webp (WASM) | 180 | 11.4 | 335 KB | 12 |
-| nativewebp (Pure Go) | 272 | 7.4 | 85 MB | 2,155 |
-| chai2010/webp (CGo) | 899 | 1.9 | 2.5 MB | 4 |
+| **deepteams/webp** (Pure Go) | **116** | 15.8 | 20.1 MB | 1,177 |
+| gen2brain/webp (WASM) | 187 | 11.0 | 335 KB | 12 |
+| nativewebp (Pure Go) | 280 | 7.2 | 85 MB | 2,155 |
+| chai2010/webp (CGo) | 929 | 1.9 | 2.5 MB | 4 |
 
 ### Decode Lossy (1536x1024)
 
 | Library | Time (ms) | MB/s | B/op | Allocs |
 |---------|----------:|-----:|-----:|-------:|
-| **deepteams/webp** (Pure Go) | **9.0** | 21.4 | 2.5 MB | 7 |
-| chai2010/webp (CGo) | 9.4 | 22.4 | 6.4 MB | 23 |
-| golang.org/x/image/webp | 17.8 | 10.8 | 2.5 MB | 13 |
-| gen2brain/webp (WASM) | 21.9 | 11.6 | 608 KB | 40 |
+| **deepteams/webp** (Pure Go) | **9.3** | 20.7 | 2.5 MB | 7 |
+| chai2010/webp (CGo) | 9.6 | 21.8 | 6.4 MB | 23 |
+| golang.org/x/image/webp | 18.4 | 10.5 | 2.5 MB | 13 |
+| gen2brain/webp (WASM) | 22.2 | 11.4 | 608 KB | 40 |
 
 ### Decode Lossless (1536x1024)
 
 | Library | Time (ms) | MB/s | B/op | Allocs |
 |---------|----------:|-----:|-----:|-------:|
-| chai2010/webp (CGo) | **19.5** | 91.5 | 10.2 MB | 30 |
-| **deepteams/webp** (Pure Go) | **20.0** | 91.3 | 7.9 MB | 226 |
-| gen2brain/webp (WASM) | 34.3 | 60.2 | 4.4 MB | 46 |
-| nativewebp (Pure Go) | 36.7 | 54.9 | 6.1 MB | 50 |
-| golang.org/x/image/webp | 39.4 | 45.2 | 6.8 MB | 966 |
-
-Note: each library decodes its own encoder's output. When decoding the *same* bitstream, deepteams/webp and chai2010 CGo are at statistical parity (19.8 vs 19.8 ms on the deepteams-encoded file).
+| **deepteams/webp** (Pure Go) | **17.0** | 107.3 | 8.3 MB | 225 |
+| chai2010/webp (CGo) | 19.2 | 91.3 | 10.2 MB | 30 |
+| gen2brain/webp (WASM) | 34.0 | 60.4 | 4.4 MB | 46 |
+| nativewebp (Pure Go) | 35.6 | 56.5 | 6.1 MB | 50 |
+| golang.org/x/image/webp | 38.7 | 47.3 | 6.8 MB | 966 |
 
 ### Encode Lossy Small (Quality 75, 256x256)
 
@@ -62,17 +60,17 @@ Note: each library decodes its own encoder's output. When decoding the *same* bi
 |---------|----------:|-----:|-------:|
 | gen2brain/webp (WASM) | **2.2** | 257 B | 12 |
 | **deepteams/webp** (Pure Go) | **2.4** | 31 KB | 127 |
-| chai2010/webp (CGo) | 4.1 | 776 KB | 131,077 |
+| chai2010/webp (CGo) | 3.9 | 776 KB | 131,077 |
 
 ## Key Takeaways
 
-1. **Fastest lossy encoder overall**: deepteams/webp (47.2ms) is the fastest lossy encoder, 14% faster than gen2brain WASM (54.9ms) and 36% faster than chai2010 CGo (73.2ms). Uses only 1.2 MB per encode with 174 allocs.
+1. **Fastest lossy encoder overall**: deepteams/webp (47.8ms) is the fastest lossy encoder, 16% faster than gen2brain WASM (56.9ms) and 37% faster than chai2010 CGo (76.4ms). Uses only 1.2 MB per encode with 166 allocs.
 
-2. **Fastest lossless encoder overall**: deepteams/webp lossless encode (114ms) is 37% faster than gen2brain WASM (180ms), 2.4x faster than nativewebp, and 7.9x faster than chai2010 CGo. Best compression among pure Go (1.8 MB compressed output).
+2. **Fastest lossless encoder overall**: deepteams/webp lossless encode (116ms) is 38% faster than gen2brain WASM (187ms), 2.4x faster than nativewebp, and 8.0x faster than chai2010 CGo. Best compression among pure Go (1.8 MB compressed output).
 
-3. **Fastest lossy decoder overall**: deepteams/webp lossy decode (9.0ms) beats chai2010 CGo (9.4ms) thanks to NEON loop filters and predictors on arm64, and is 2.0x faster than x/image/webp and 2.4x faster than gen2brain WASM. Lowest memory (2.5 MB) and fewest allocs (7) of any decoder — and `webp.DecodeReuse` drops steady-state decode allocations to a few KB by recycling the output buffers.
+3. **Fastest lossy decoder overall**: deepteams/webp lossy decode (9.3ms) beats chai2010 CGo (9.6ms) thanks to NEON loop filters and predictors on arm64, and is 2.0x faster than x/image/webp and 2.4x faster than gen2brain WASM. Lowest memory (2.5 MB) and fewest allocs (7) of any decoder — and `webp.DecodeReuse` drops steady-state decode allocations to a few KB by recycling the output buffers.
 
-4. **Fastest pure Go lossless decoder**: deepteams/webp lossless decode (20.0ms) is 42% faster than gen2brain, 45% faster than nativewebp, and 49% faster than x/image — within 3% of chai2010 CGo, and at statistical parity with it on identical bitstreams thanks to NEON inverse transforms (predictors, cross-color, ARGB conversion).
+4. **Fastest lossless decoder overall**: deepteams/webp lossless decode (17.0ms) beats chai2010 CGo (19.2ms) by 11%, and is 2.0x faster than gen2brain, 2.1x faster than nativewebp, and 2.3x faster than x/image — thanks to SIMD inverse transforms (predictors, cross-color, ARGB conversion) and a register-resident entropy decoding loop.
 
 5. **Consistent performance**: 10-run medians show deepteams/webp is stable (low variance) across lossy/lossless encoding and decoding, with only minor outliers under system contention.
 

--- a/internal/bitio/reader_lossless.go
+++ b/internal/bitio/reader_lossless.go
@@ -128,6 +128,32 @@ func (br *LosslessReader) IsEndOfStream() bool {
 	return br.eos || (br.pos == br.len_ && br.bitPos > vp8lLBits)
 }
 
+// State returns the reader's hot state (prefetched bits, bit position, byte
+// position) so that tight decode loops can keep it in local variables and
+// avoid reloading it through the pointer on every access. Callers must write
+// the state back with SetState before invoking any other reader method.
+func (br *LosslessReader) State() (val uint64, bitPos, pos int) {
+	return br.val, br.bitPos, br.pos
+}
+
+// SetState writes back state previously obtained from State (and possibly
+// advanced locally by the caller).
+func (br *LosslessReader) SetState(val uint64, bitPos, pos int) {
+	br.val, br.bitPos, br.pos = val, bitPos, pos
+}
+
+// Data returns the underlying input buffer. Together with State/SetState it
+// lets hot loops inline the 4-byte fast refill locally; the slow tail path
+// must go through SetState + FillBitWindow.
+func (br *LosslessReader) Data() []byte {
+	return br.buf
+}
+
+// Eos reports the sticky end-of-stream flag (set by the slow refill path).
+func (br *LosslessReader) Eos() bool {
+	return br.eos
+}
+
 // kBitMask maps nBits (0..24) to the corresponding mask (2^n - 1).
 var kBitMask = [vp8lMaxNumBitRead + 1]uint32{
 	0x000000, // 0

--- a/internal/lossless/decode_image.go
+++ b/internal/lossless/decode_image.go
@@ -6,7 +6,11 @@ package lossless
 // Reference: libwebp/src/dec/vp8l_dec.c (ReadHuffmanCode, ReadHuffmanCodes,
 // ReadHuffmanCodesHelper, DecodeImageData).
 
-import "github.com/deepteams/webp/internal/bitio"
+import (
+	"encoding/binary"
+
+	"github.com/deepteams/webp/internal/bitio"
+)
 
 // readHuffmanCodeLengths decodes Huffman-coded code lengths using a previously
 // built code-lengths Huffman table.
@@ -400,39 +404,8 @@ func getCopyDistance(distanceSymbol int, br *bitio.LosslessReader) int {
 	return offset + int(br.ReadBits(extraBits)) + 1
 }
 
-// getCopyLength decodes the length from a length symbol.
-func getCopyLength(lengthSymbol int, br *bitio.LosslessReader) int {
-	return getCopyDistance(lengthSymbol, br) // same encoding
-}
 
-// readSymbolFromTree decodes one Huffman symbol from a table using the
-// bit reader, performing the necessary fill/prefetch.
-// Uses concrete *bitio.LosslessReader so FillBitWindow/PrefetchBits/
-// SetBitPos/BitPos can inline (avoiding interface dispatch overhead).
-func readSymbolFromTree(table []HuffmanCode, br *bitio.LosslessReader) (int, bool) {
-	br.FillBitWindow()
-	val, bitsUsed := ReadSymbol(table, br.PrefetchBits())
-	if bitsUsed < 0 {
-		return 0, false
-	}
-	br.SetBitPos(br.BitPos() + bitsUsed)
-	return int(val), true
-}
 
-// readPackedSymbols attempts to decode an entire ARGB pixel from the
-// packed table. Returns (value, code) where code == 0 means a full
-// literal was decoded into *dst, otherwise code is the non-literal symbol.
-// Uses concrete *bitio.LosslessReader for method inlining.
-func readPackedSymbols(group *HTreeGroup, br *bitio.LosslessReader) (argb uint32, greenCode int, isLiteral bool) {
-	bits := br.PrefetchBits() & (HuffmanPackedTableSize - 1)
-	code := group.PackedTable[bits]
-	if code.Bits < bitsSpecialMarker {
-		br.SetBitPos(br.BitPos() + code.Bits)
-		return code.Value, 0, true
-	}
-	br.SetBitPos(br.BitPos() + code.Bits - bitsSpecialMarker)
-	return 0, int(code.Value), false
-}
 
 // decodeImageData is the main entropy-coding decode loop. It decodes
 // width*height pixels into data[], using the Huffman trees in dec.hdr.
@@ -456,6 +429,17 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 	colorCacheLimit := lenCodeLimit + hdr.colorCacheSize
 	colorCache := hdr.colorCache
 	mask := hdr.huffmanMask
+
+	// Register-resident bit-reader state (same technique as getCoeffsInline
+	// in the lossy decoder): val/bitPos/rpos live in locals so that stores
+	// to data[] don't force reloads through the br pointer on every symbol.
+	// The 4-byte refill fast path is inlined; the slow tail path syncs via
+	// SetState, delegates to FillBitWindow, and reloads. EOS tests replicate
+	// IsEndOfStream on the local state.
+	buf := br.Data()
+	bufLen := len(buf)
+	val, bitPos, rpos := br.State()
+	eos := br.Eos()
 
 	pos := 0
 	lastCached := 0 // 8.2: exact position tracking like C's last_cached pointer
@@ -500,20 +484,40 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 			continue
 		}
 
-		br.FillBitWindow()
+		// FillBitWindow, inlined fast path.
+		if bitPos >= 32 {
+			if rpos+4 <= bufLen {
+				val = val>>32 | uint64(binary.LittleEndian.Uint32(buf[rpos:]))<<32
+				rpos += 4
+				bitPos -= 32
+			} else {
+				br.SetState(val, bitPos, rpos)
+				br.FillBitWindow()
+				val, bitPos, rpos = br.State()
+				eos = br.Eos()
+			}
+		}
 
 		var code int
 		if htreeGroup.UsePackedTable {
-			// 8.6: Packed table path. C's ReadPackedSymbols writes directly
-			// to *src and returns PACKED_NON_LITERAL_CODE (0) for literals.
-			// When literal, write to data[pos] and do AdvanceByOne (no
-			// immediate per-pixel cache insertion).
-			argb, gc, isLit := readPackedSymbols(htreeGroup, br)
-			if br.IsEndOfStream() {
+			// 8.6: Packed table path (inlined readPackedSymbols). C's
+			// ReadPackedSymbols writes directly to *src and returns
+			// PACKED_NON_LITERAL_CODE (0) for literals. When literal, write
+			// to data[pos] and do AdvanceByOne (no immediate per-pixel
+			// cache insertion).
+			pbits := uint32(val>>(uint(bitPos)&63)) & (HuffmanPackedTableSize - 1)
+			pcode := htreeGroup.PackedTable[pbits]
+			isLit := pcode.Bits < bitsSpecialMarker
+			if isLit {
+				bitPos += pcode.Bits
+			} else {
+				bitPos += pcode.Bits - bitsSpecialMarker
+			}
+			if eos || (rpos == bufLen && bitPos > 64) {
 				break
 			}
 			if isLit {
-				data[pos] = argb
+				data[pos] = pcode.Value
 				pos++
 				col++
 				if col >= width {
@@ -528,21 +532,21 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 				}
 				continue
 			}
-			code = gc
+			code = int(pcode.Value)
 		} else {
 			// Inline readSymbolFromTree for green.
-			// FillBitWindow already called above — no redundant fill needed.
-			prefetch := br.PrefetchBits()
-			val, bits := ReadSymbol(htreeGroup.HTrees[int(HuffGreen)], prefetch)
+			// FillBitWindow already done above — no redundant fill needed.
+			prefetch := uint32(val >> (uint(bitPos) & 63))
+			v, bits := ReadSymbol(htreeGroup.HTrees[int(HuffGreen)], prefetch)
 			if bits < 0 {
 				return ErrBitstream
 			}
-			br.SetBitPos(br.BitPos() + bits)
-			code = int(val)
+			bitPos += bits
+			code = int(v)
 		}
 
 		// 8.7: EOS check after GREEN symbol (C has this at line 1259).
-		if br.IsEndOfStream() {
+		if eos || (rpos == bufLen && bitPos > 64) {
 			break
 		}
 
@@ -553,35 +557,46 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 			} else {
 				// Inline readSymbolFromTree for red.
 				// After green (≤15 bits), ≥17 bits remain — no fill needed.
-				prefetch := br.PrefetchBits()
+				prefetch := uint32(val >> (uint(bitPos) & 63))
 				redVal, redBits := ReadSymbol(htreeGroup.HTrees[int(HuffRed)], prefetch)
 				if redBits < 0 {
 					return ErrBitstream
 				}
-				br.SetBitPos(br.BitPos() + redBits)
+				bitPos += redBits
 
 				// Fill before blue+alpha (green+red consumed ≤30 bits).
-				br.FillBitWindow()
+				if bitPos >= 32 {
+					if rpos+4 <= bufLen {
+						val = val>>32 | uint64(binary.LittleEndian.Uint32(buf[rpos:]))<<32
+						rpos += 4
+						bitPos -= 32
+					} else {
+						br.SetState(val, bitPos, rpos)
+						br.FillBitWindow()
+						val, bitPos, rpos = br.State()
+						eos = br.Eos()
+					}
+				}
 
 				// Inline readSymbolFromTree for blue.
-				prefetch = br.PrefetchBits()
+				prefetch = uint32(val >> (uint(bitPos) & 63))
 				blueVal, blueBits := ReadSymbol(htreeGroup.HTrees[int(HuffBlue)], prefetch)
 				if blueBits < 0 {
 					return ErrBitstream
 				}
-				br.SetBitPos(br.BitPos() + blueBits)
+				bitPos += blueBits
 
 				// Inline readSymbolFromTree for alpha.
 				// After blue (≤15 bits), ≥17 bits remain — no fill needed.
-				prefetch = br.PrefetchBits()
+				prefetch = uint32(val >> (uint(bitPos) & 63))
 				alphaVal, alphaBits := ReadSymbol(htreeGroup.HTrees[int(HuffAlpha)], prefetch)
 				if alphaBits < 0 {
 					return ErrBitstream
 				}
-				br.SetBitPos(br.BitPos() + alphaBits)
+				bitPos += alphaBits
 
 				// 8.7: Second EOS check after all symbols (C line 1269).
-				if br.IsEndOfStream() {
+				if eos || (rpos == bufLen && bitPos > 64) {
 					break
 				}
 				data[pos] = (uint32(alphaVal) << 24) | (uint32(redVal) << 16) | (uint32(code) << 8) | uint32(blueVal)
@@ -610,19 +625,41 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 			} else {
 				extraBits := (lengthSym - 2) >> 1
 				offset := (2 + (lengthSym & 1)) << extraBits
-				br.FillBitWindow()
-				length = offset + int(br.PrefetchBits()&uint32((1<<extraBits)-1)) + 1
-				br.SetBitPos(br.BitPos() + extraBits)
+				if bitPos >= 32 {
+					if rpos+4 <= bufLen {
+						val = val>>32 | uint64(binary.LittleEndian.Uint32(buf[rpos:]))<<32
+						rpos += 4
+						bitPos -= 32
+					} else {
+						br.SetState(val, bitPos, rpos)
+						br.FillBitWindow()
+						val, bitPos, rpos = br.State()
+						eos = br.Eos()
+					}
+				}
+				length = offset + int(uint32(val>>(uint(bitPos)&63))&uint32((1<<extraBits)-1)) + 1
+				bitPos += extraBits
 			}
 
 			// Inline readSymbolFromTree for distance.
-			br.FillBitWindow()
-			prefetch := br.PrefetchBits()
+			if bitPos >= 32 {
+				if rpos+4 <= bufLen {
+					val = val>>32 | uint64(binary.LittleEndian.Uint32(buf[rpos:]))<<32
+					rpos += 4
+					bitPos -= 32
+				} else {
+					br.SetState(val, bitPos, rpos)
+					br.FillBitWindow()
+					val, bitPos, rpos = br.State()
+					eos = br.Eos()
+				}
+			}
+			prefetch := uint32(val >> (uint(bitPos) & 63))
 			distVal, distBits := ReadSymbol(htreeGroup.HTrees[int(HuffDist)], prefetch)
 			if distBits < 0 {
 				return ErrBitstream
 			}
-			br.SetBitPos(br.BitPos() + distBits)
+			bitPos += distBits
 			distSymbol := int(distVal)
 
 			// Inline getCopyDistance.
@@ -632,13 +669,24 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 			} else {
 				dExtraBits := (distSymbol - 2) >> 1
 				dOffset := (2 + (distSymbol & 1)) << dExtraBits
-				br.FillBitWindow()
-				distCode = dOffset + int(br.PrefetchBits()&uint32((1<<dExtraBits)-1)) + 1
-				br.SetBitPos(br.BitPos() + dExtraBits)
+				if bitPos >= 32 {
+					if rpos+4 <= bufLen {
+						val = val>>32 | uint64(binary.LittleEndian.Uint32(buf[rpos:]))<<32
+						rpos += 4
+						bitPos -= 32
+					} else {
+						br.SetState(val, bitPos, rpos)
+						br.FillBitWindow()
+						val, bitPos, rpos = br.State()
+						eos = br.Eos()
+					}
+				}
+				distCode = dOffset + int(uint32(val>>(uint(bitPos)&63))&uint32((1<<dExtraBits)-1)) + 1
+				bitPos += dExtraBits
 			}
 			dist := PlaneCodeToDistance(width, distCode)
 
-			if br.IsEndOfStream() {
+			if eos || (rpos == bufLen && bitPos > 64) {
 				break
 			}
 			// 8.4: Bounds check. pos is equivalent to C's (src - data).
@@ -701,6 +749,9 @@ func (dec *Decoder) decodeImageData(data []uint32, width, height, lastRow int) e
 			return ErrBitstream
 		}
 	}
+
+	// Write the register-resident reader state back before leaving.
+	br.SetState(val, bitPos, rpos)
 
 	if br.IsEndOfStream() && pos < srcEnd {
 		return ErrBitstream


### PR DESCRIPTION
**Lossless decoding −14%** (20.3 → 17.4 ms on the comparative photo protocol)