### PR TITLE
Fix lossy VP8 color-range contraction and optimize NRGBA decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ func main() {
 }
 ```
 
+Lossy VP8 pixels are returned as `*image.NRGBA`. VP8 stores limited-range
+BT.601 YUV, while Go's `image.YCbCr` uses full-range JPEG semantics; converting
+during decode prevents black/white range contraction in standard `image`
+consumers and repeated WebP transcodes.
+
 ### Decode in a loop (zero-allocation)
 
 When decoding many images of similar size (thumbnails, video frames, batch

--- a/color_range_test.go
+++ b/color_range_test.go
@@ -1,0 +1,106 @@
+package webp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestDecodeLossyPreservesVideoRangeEndpoints(t *testing.T) {
+	fixtures := []struct {
+		name  string
+		data  string
+		white bool
+	}{
+		{
+			name: "black",
+			data: "UklGRjYAAABXRUJQVlA4ICoAAAAwAwCdASpAAEAAPj0ejUQhBEEABMDxPSAAAgbqagCvELcgAP7+BtAAAAA=",
+		},
+		{
+			name:  "white",
+			data:  "UklGRjYAAABXRUJQVlA4ICoAAAAwAwCdASpAAEAAPj0ejUQhBEEABMDxPSAAAgbqagCvELcgAP79wIAAAAA=",
+			white: true,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			data, err := base64.StdEncoding.DecodeString(fixture.data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := Decode(bytes.NewReader(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := decoded.(*image.NRGBA); !ok {
+				t.Fatalf("decoded type = %T, want *image.NRGBA", decoded)
+			}
+			assertEndpoint(t, decoded.At(32, 32), fixture.white)
+		})
+	}
+}
+
+func assertEndpoint(t *testing.T, pixel color.Color, white bool) {
+	t.Helper()
+	c := color.NRGBAModel.Convert(pixel).(color.NRGBA)
+	if white {
+		if c.R < 251 || c.G < 251 || c.B < 251 {
+			t.Fatalf("white = %v, want every RGB channel >= 251", c)
+		}
+		return
+	}
+	if c.R > 4 || c.G > 4 || c.B > 4 {
+		t.Fatalf("black = %v, want every RGB channel <= 4", c)
+	}
+}
+
+func TestLossyDecodeEncodeDoesNotProgressivelyContractRange(t *testing.T) {
+	var current image.Image = blackAndWhiteImage()
+	for generation := 1; generation <= 3; generation++ {
+		data := encodeBlackAndWhiteLossy(t, current)
+		decoded, err := Decode(bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("generation %d: %v", generation, err)
+		}
+		assertBlackAndWhiteEndpoints(t, decoded, generation)
+		current = decoded
+	}
+}
+
+func blackAndWhiteImage() *image.NRGBA {
+	img := image.NewNRGBA(image.Rect(0, 0, 64, 64))
+	for y := 0; y < img.Bounds().Dy(); y++ {
+		for x := 0; x < img.Bounds().Dx(); x++ {
+			c := color.NRGBA{A: 255}
+			if x >= img.Bounds().Dx()/2 {
+				c.R, c.G, c.B = 255, 255, 255
+			}
+			img.SetNRGBA(x, y, c)
+		}
+	}
+	return img
+}
+
+func encodeBlackAndWhiteLossy(t *testing.T, img image.Image) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Encode(&buf, img, &EncoderOptions{Quality: 100, Method: 4}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func assertBlackAndWhiteEndpoints(t *testing.T, img image.Image, generation int) {
+	t.Helper()
+	black := color.NRGBAModel.Convert(img.At(8, 32)).(color.NRGBA)
+	white := color.NRGBAModel.Convert(img.At(56, 32)).(color.NRGBA)
+	if black.R > 4 || black.G > 4 || black.B > 4 {
+		t.Errorf("generation %d black = %v, want every RGB channel <= 4", generation, black)
+	}
+	if white.R < 251 || white.G < 251 || white.B < 251 {
+		t.Errorf("generation %d white = %v, want every RGB channel >= 251", generation, white)
+	}
+}

--- a/decode_reuse_test.go
+++ b/decode_reuse_test.go
@@ -74,15 +74,11 @@ func TestDecodeReuseMatchesDecode(t *testing.T) {
 }
 
 func TestDecodeReuseIncompatibleFallsBack(t *testing.T) {
-	dataLossy := encodeTestWebP(t, false, false)   // → *image.YCbCr
-	dataLossless := encodeTestWebP(t, true, false) // → *image.NRGBA
+	dataLossless := encodeTestWebP(t, true, false)
 
 	// Reuse of the wrong type must be ignored, not crash.
-	img1, err := DecodeReuse(bytes.NewReader(dataLossy), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	img2, err := DecodeReuse(bytes.NewReader(dataLossless), img1)
+	wrongType := image.NewYCbCr(image.Rect(0, 0, 160, 120), image.YCbCrSubsampleRatio420)
+	img2, err := DecodeReuse(bytes.NewReader(dataLossless), wrongType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/dsp/upsample_direct_amd64.go
+++ b/internal/dsp/upsample_direct_amd64.go
@@ -15,23 +15,37 @@ func UpsampleLinePairNRGBA(
 	alphaTop, alphaBot []byte,
 	width int,
 ) {
+	const maxStackWidth = 2048
+	var stackBuf [maxStackWidth * 2]uint32
+	UpsampleLinePairNRGBAWithScratch(
+		topY, botY, topU, topV, botU, botV, topDst, botDst,
+		alphaTop, alphaBot, width, stackBuf[:],
+	)
+}
+
+// UpsampleLinePairNRGBAWithScratch is equivalent to
+// UpsampleLinePairNRGBA but reuses caller-provided packed-UV storage.
+func UpsampleLinePairNRGBAWithScratch(
+	topY, botY []byte,
+	topU, topV []byte,
+	botU, botV []byte,
+	topDst, botDst []byte,
+	alphaTop, alphaBot []byte,
+	width int,
+	packedUV []uint32,
+) {
 	if width <= 0 {
 		return
 	}
 
-	// Packed UV temp buffer (one uint32 per pixel per row).
-	// Use stack-allocated array for common widths to avoid heap allocation.
-	const maxStackWidth = 2048
 	uvCount := width
 	if botY != nil {
 		uvCount = width * 2
 	}
-	var stackBuf [maxStackWidth * 2]uint32
-	var packedUV []uint32
-	if uvCount <= len(stackBuf) {
-		packedUV = stackBuf[:uvCount]
-	} else {
+	if cap(packedUV) < uvCount {
 		packedUV = make([]uint32, uvCount)
+	} else {
+		packedUV = packedUV[:uvCount]
 	}
 	tUV := packedUV[:width]
 	var bUV []uint32

--- a/internal/dsp/upsample_direct_arm64.go
+++ b/internal/dsp/upsample_direct_arm64.go
@@ -18,23 +18,37 @@ func UpsampleLinePairNRGBA(
 	alphaTop, alphaBot []byte,
 	width int,
 ) {
+	const maxStackWidth = 2048
+	var stackBuf [maxStackWidth * 2]uint32
+	UpsampleLinePairNRGBAWithScratch(
+		topY, botY, topU, topV, botU, botV, topDst, botDst,
+		alphaTop, alphaBot, width, stackBuf[:],
+	)
+}
+
+// UpsampleLinePairNRGBAWithScratch is equivalent to
+// UpsampleLinePairNRGBA but reuses caller-provided packed-UV storage.
+func UpsampleLinePairNRGBAWithScratch(
+	topY, botY []byte,
+	topU, topV []byte,
+	botU, botV []byte,
+	topDst, botDst []byte,
+	alphaTop, alphaBot []byte,
+	width int,
+	packedUV []uint32,
+) {
 	if width <= 0 {
 		return
 	}
 
-	// Packed UV temp buffer (one uint32 per pixel per row).
-	// Use stack-allocated array for common widths to avoid heap allocation.
-	const maxStackWidth = 2048
 	uvCount := width
 	if botY != nil {
 		uvCount = width * 2
 	}
-	var stackBuf [maxStackWidth * 2]uint32
-	var packedUV []uint32
-	if uvCount <= len(stackBuf) {
-		packedUV = stackBuf[:uvCount]
-	} else {
+	if cap(packedUV) < uvCount {
 		packedUV = make([]uint32, uvCount)
+	} else {
+		packedUV = packedUV[:uvCount]
 	}
 	tUV := packedUV[:width]
 	var bUV []uint32

--- a/internal/dsp/upsample_direct_noasm.go
+++ b/internal/dsp/upsample_direct_noasm.go
@@ -15,3 +15,17 @@ func UpsampleLinePairNRGBA(
 ) {
 	upsampleLinePairNRGBAGo(topY, botY, topU, topV, botU, botV, topDst, botDst, alphaTop, alphaBot, width)
 }
+
+// UpsampleLinePairNRGBAWithScratch is equivalent to
+// UpsampleLinePairNRGBA. The pure Go implementation does not need scratch.
+func UpsampleLinePairNRGBAWithScratch(
+	topY, botY []byte,
+	topU, topV []byte,
+	botU, botV []byte,
+	topDst, botDst []byte,
+	alphaTop, alphaBot []byte,
+	width int,
+	_ []uint32,
+) {
+	upsampleLinePairNRGBAGo(topY, botY, topU, topV, botU, botV, topDst, botDst, alphaTop, alphaBot, width)
+}

--- a/internal/dsp/upsample_test.go
+++ b/internal/dsp/upsample_test.go
@@ -1,6 +1,7 @@
 package dsp
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 )
@@ -29,14 +30,16 @@ func TestLoadUV(t *testing.T) {
 // the correct values for a known 2x2 chroma block.
 //
 // Given chroma:
-//   [a b]   =  [100 200]
-//   [c d]      [150 250]
+//
+//	[a b]   =  [100 200]
+//	[c d]      [150 250]
 //
 // The four interpolated sub-pixels should be:
-//   top-left  = (9*a + 3*b + 3*c +   d + 8) / 16 = (900+600+450+250+8)/16 = 137
-//   top-right = (3*a + 9*b +   c + 3*d + 8) / 16 = (300+1800+150+750+8)/16 = 188
-//   bot-left  = (3*a +   b + 9*c + 3*d + 8) / 16 = (300+200+1350+750+8)/16 = 163
-//   bot-right = (  a + 3*b + 3*c + 9*d + 8) / 16 = (100+600+450+2250+8)/16 = 213
+//
+//	top-left  = (9*a + 3*b + 3*c +   d + 8) / 16 = (900+600+450+250+8)/16 = 137
+//	top-right = (3*a + 9*b +   c + 3*d + 8) / 16 = (300+1800+150+750+8)/16 = 188
+//	bot-left  = (3*a +   b + 9*c + 3*d + 8) / 16 = (300+200+1350+750+8)/16 = 163
+//	bot-right = (  a + 3*b + 3*c + 9*d + 8) / 16 = (100+600+450+2250+8)/16 = 213
 func TestDiamondKernelValues(t *testing.T) {
 	// We use a 2-pixel wide image (width=2) so the upsampler produces exactly
 	// 2 luma columns from 1 pair of chroma samples.
@@ -385,6 +388,38 @@ func TestUpsampleLinePairNRGBAConformanceNilBot(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestUpsampleLinePairNRGBAWithScratchMatchesDispatch(t *testing.T) {
+	const width = 65
+	rng := rand.New(rand.NewSource(101))
+	chromaW := (width + 1) / 2
+	topY := makeRandBuf(rng, width)
+	botY := makeRandBuf(rng, width)
+	topU := makeRandBuf(rng, chromaW)
+	topV := makeRandBuf(rng, chromaW)
+	botU := makeRandBuf(rng, chromaW)
+	botV := makeRandBuf(rng, chromaW)
+	alphaTop := makeRandBuf(rng, width)
+	alphaBot := makeRandBuf(rng, width)
+
+	wantTop := make([]byte, width*4)
+	wantBot := make([]byte, width*4)
+	UpsampleLinePairNRGBA(topY, botY, topU, topV, botU, botV,
+		wantTop, wantBot, alphaTop, alphaBot, width)
+
+	gotTop := make([]byte, width*4)
+	gotBot := make([]byte, width*4)
+	scratch := make([]uint32, width*2)
+	UpsampleLinePairNRGBAWithScratch(topY, botY, topU, topV, botU, botV,
+		gotTop, gotBot, alphaTop, alphaBot, width, scratch)
+
+	if !bytes.Equal(gotTop, wantTop) {
+		t.Fatal("top row differs when caller-provided scratch is used")
+	}
+	if !bytes.Equal(gotBot, wantBot) {
+		t.Fatal("bottom row differs when caller-provided scratch is used")
 	}
 }
 

--- a/webp.go
+++ b/webp.go
@@ -83,8 +83,7 @@ func readAll(r io.Reader) ([]byte, error) {
 }
 
 // Decode reads a WebP image from r and returns it as an image.Image.
-// For lossless images the returned type is *image.NRGBA.
-// For lossy images the returned type is *image.YCbCr (when available) or *image.NRGBA.
+// Decode returns decoded pixels as *image.NRGBA.
 func Decode(r io.Reader) (image.Image, error) {
 	return DecodeReuse(r, nil)
 }
@@ -133,21 +132,8 @@ func DecodeConfig(r io.Reader) (image.Config, error) {
 
 	feat := p.Features()
 
-	// Determine color model to match what Decode() actually returns:
-	//   - VP8L (lossless) always decodes to *image.NRGBA
-	//   - VP8 (lossy) without alpha decodes to *image.YCbCr
-	//   - VP8 (lossy) with alpha decodes to *image.NRGBA
-	cm := color.NRGBAModel
-	if frames := p.Frames(); len(frames) > 0 {
-		if !frames[0].IsLossless && frames[0].AlphaData == nil {
-			cm = color.YCbCrModel
-		}
-	} else if !feat.HasAlpha {
-		cm = color.YCbCrModel
-	}
-
 	return image.Config{
-		ColorModel: cm,
+		ColorModel: color.NRGBAModel,
 		Width:      feat.Width,
 		Height:     feat.Height,
 	}, nil
@@ -172,12 +158,12 @@ func GetFeatures(r io.Reader) (*Features, error) {
 
 	feat := p.Features()
 	f := &Features{
-		Width:      feat.Width,
-		Height:     feat.Height,
-		HasAlpha:   feat.HasAlpha,
+		Width:        feat.Width,
+		Height:       feat.Height,
+		HasAlpha:     feat.HasAlpha,
 		HasAnimation: feat.HasAnim,
-		FrameCount: len(p.Frames()),
-		LoopCount:  feat.LoopCount,
+		FrameCount:   len(p.Frames()),
+		LoopCount:    feat.LoopCount,
 	}
 
 	switch feat.Format {
@@ -276,71 +262,11 @@ func decodeFrameForAnimation(bitstreamData, alphaData []byte) (*image.NRGBA, err
 	if err != nil {
 		return nil, err
 	}
-	// Convert to NRGBA if needed.
-	if nrgba, ok := img.(*image.NRGBA); ok {
-		return nrgba, nil
-	}
-	// Fast path for *image.YCbCr (lossy without alpha).
-	if ycbcr, ok := img.(*image.YCbCr); ok {
-		return ycbcrToNRGBA(ycbcr), nil
-	}
-	b := img.Bounds()
-	nrgba := image.NewNRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
-	for y := b.Min.Y; y < b.Max.Y; y++ {
-		for x := b.Min.X; x < b.Max.X; x++ {
-			nrgba.Set(x-b.Min.X, y-b.Min.Y, img.At(x, y))
-		}
-	}
-	return nrgba, nil
+	return img.(*image.NRGBA), nil
 }
 
-// ycbcrToNRGBA converts a 4:2:0 YCbCr image to NRGBA using direct
-// YCbCr→RGB conversion (no fancy upsampling, as animation compositing
-// doesn't require it).
-func ycbcrToNRGBA(ycbcr *image.YCbCr) *image.NRGBA {
-	w := ycbcr.Rect.Dx()
-	h := ycbcr.Rect.Dy()
-	nrgba := image.NewNRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		yi := y * ycbcr.YStride
-		ci := (y >> 1) * ycbcr.CStride
-		di := y * nrgba.Stride
-		for x := 0; x < w; x++ {
-			yy := int32(ycbcr.Y[yi+x])
-			cb := int32(ycbcr.Cb[ci+(x>>1)]) - 128
-			cr := int32(ycbcr.Cr[ci+(x>>1)]) - 128
-			r := yy + (91881*cr+32768)>>16
-			g := yy - (22554*cb+46802*cr+32768)>>16
-			b := yy + (116130*cb+32768)>>16
-			if r < 0 {
-				r = 0
-			} else if r > 255 {
-				r = 255
-			}
-			if g < 0 {
-				g = 0
-			} else if g > 255 {
-				g = 255
-			}
-			if b < 0 {
-				b = 0
-			} else if b > 255 {
-				b = 255
-			}
-			nrgba.Pix[di] = byte(r)
-			nrgba.Pix[di+1] = byte(g)
-			nrgba.Pix[di+2] = byte(b)
-			nrgba.Pix[di+3] = 255
-			di += 4
-		}
-	}
-	return nrgba
-}
-
-// decodeLossy decodes a VP8 lossy bitstream.
-// Without alpha data it returns *image.YCbCr (4:2:0) — no colour-space
-// conversion needed, just a plane copy.  With alpha it falls back to
-// *image.NRGBA using fancy chroma upsampling.
+// decodeLossy decodes a VP8 lossy bitstream to NRGBA using fancy chroma
+// upsampling and WebP's limited-range BT.601 YUV conversion.
 func decodeLossy(data []byte, alphaData []byte, reuse image.Image) (image.Image, error) {
 	dec, width, height, yPlane, yStride, uPlane, vPlane, uvStride, err := lossy.DecodeFrame(data)
 	if err != nil {
@@ -357,52 +283,8 @@ func decodeLossy(data []byte, alphaData []byte, reuse image.Image) (image.Image,
 		}
 	}
 
-	// Fast path: no alpha → return *image.YCbCr directly.
-	if alphaPlane == nil {
-		prev, _ := reuse.(*image.YCbCr)
-		return buildYCbCr(width, height, yPlane, yStride, uPlane, vPlane, uvStride, prev), nil
-	}
-
-	// Slow path: alpha present → NRGBA with fancy chroma upsampling.
 	prev, _ := reuse.(*image.NRGBA)
 	return buildNRGBA(width, height, yPlane, yStride, uPlane, vPlane, uvStride, alphaPlane, prev), nil
-}
-
-// buildYCbCr copies the decoder's Y/U/V cache planes into an image.YCbCr.
-// The decoder's slab is returned to the pool after this function, so the
-// data must be copied out. If reuse comes from a previous buildYCbCr call
-// and its contiguous backing buffer is large enough, it is reused.
-func buildYCbCr(width, height int, yPlane []byte, yStride int, uPlane, vPlane []byte, uvStride int, reuse *image.YCbCr) *image.YCbCr {
-	chromaH := (height + 1) / 2
-
-	yLen := height * yStride
-	cLen := chromaH * uvStride
-	totalSize := uint64(yLen) + 2*uint64(cLen)
-	if totalSize > 1<<30 {
-		return nil
-	}
-	var buf []byte
-	if reuse != nil && cap(reuse.Y) >= yLen+2*cLen {
-		// Images built here use one contiguous allocation with Y at its
-		// start, so cap(Y) sees the full buffer.
-		buf = reuse.Y[:yLen+2*cLen]
-	} else {
-		buf = make([]byte, yLen+2*cLen)
-	}
-
-	copy(buf[:yLen], yPlane[:yLen])
-	copy(buf[yLen:yLen+cLen], uPlane[:cLen])
-	copy(buf[yLen+cLen:], vPlane[:cLen])
-
-	return &image.YCbCr{
-		Y:              buf[:yLen],
-		Cb:             buf[yLen : yLen+cLen],
-		Cr:             buf[yLen+cLen:],
-		YStride:        yStride,
-		CStride:        uvStride,
-		SubsampleRatio: image.YCbCrSubsampleRatio420,
-		Rect:           image.Rect(0, 0, width, height),
-	}
 }
 
 // buildNRGBA constructs an *image.NRGBA from raw YUV planes + alpha using
@@ -444,19 +326,27 @@ func buildNRGBA(width, height int, yPlane []byte, yStride int, uPlane, vPlane []
 		off := row * img.Stride
 		return img.Pix[off : off+width*4]
 	}
+	// Reuse the packed chroma workspace across row pairs. The SIMD dispatch
+	// otherwise creates and clears the same temporary buffer for every pair.
+	const maxStackWidth = 2048
+	var stackScratch [maxStackWidth * 2]uint32
+	scratch := stackScratch[:]
+	if width > maxStackWidth {
+		scratch = make([]uint32, width*2)
+	}
 
 	if height == 1 {
-		dsp.UpsampleLinePairNRGBA(
+		dsp.UpsampleLinePairNRGBAWithScratch(
 			yRow(0), nil, uRow(0), vRow(0), uRow(0), vRow(0),
-			dstRow(0), nil, aRow(0), nil, width,
+			dstRow(0), nil, aRow(0), nil, width, scratch,
 		)
 		return img
 	}
 
 	// Row 0: mirror chroma.
-	dsp.UpsampleLinePairNRGBA(
+	dsp.UpsampleLinePairNRGBAWithScratch(
 		yRow(0), nil, uRow(0), vRow(0), uRow(0), vRow(0),
-		dstRow(0), nil, aRow(0), nil, width,
+		dstRow(0), nil, aRow(0), nil, width, scratch,
 	)
 
 	// Overlapping pairs.
@@ -464,13 +354,13 @@ func buildNRGBA(width, height int, yPlane []byte, yStride int, uPlane, vPlane []
 	for y+2 < height {
 		chromaTop := y / 2
 		chromaBot := chromaTop + 1
-		dsp.UpsampleLinePairNRGBA(
+		dsp.UpsampleLinePairNRGBAWithScratch(
 			yRow(y+1), yRow(y+2),
 			uRow(chromaTop), vRow(chromaTop),
 			uRow(chromaBot), vRow(chromaBot),
 			dstRow(y+1), dstRow(y+2),
 			aRow(y+1), aRow(y+2),
-			width,
+			width, scratch,
 		)
 		y += 2
 	}
@@ -478,13 +368,13 @@ func buildNRGBA(width, height int, yPlane []byte, yStride int, uPlane, vPlane []
 	// Last row for even-height images.
 	if height&1 == 0 {
 		lastChroma := (height - 1) / 2
-		dsp.UpsampleLinePairNRGBA(
+		dsp.UpsampleLinePairNRGBAWithScratch(
 			yRow(height-1), nil,
 			uRow(lastChroma), vRow(lastChroma),
 			uRow(lastChroma), vRow(lastChroma),
 			dstRow(height-1), nil,
 			aRow(height-1), nil,
-			width,
+			width, scratch,
 		)
 	}
 

--- a/webp_test.go
+++ b/webp_test.go
@@ -403,8 +403,8 @@ func TestDecodeConfig_LibwebpTest(t *testing.T) {
 	if cfg.Width != 128 || cfg.Height != 128 {
 		t.Errorf("dimensions = %dx%d, want 128x128", cfg.Width, cfg.Height)
 	}
-	if cfg.ColorModel != color.YCbCrModel {
-		t.Errorf("color model should be YCbCrModel for lossy without alpha")
+	if cfg.ColorModel != color.NRGBAModel {
+		t.Errorf("color model should be NRGBAModel for lossy images")
 	}
 }
 
@@ -812,7 +812,7 @@ func TestDecodeConfig_ColorModel_AllFormats(t *testing.T) {
 			name:      "lossy_opaque",
 			img:       opaqueImg,
 			opts:      &EncoderOptions{Quality: 75},
-			wantModel: color.YCbCrModel,
+			wantModel: color.NRGBAModel,
 		},
 		{
 			name:      "lossless",
@@ -838,7 +838,7 @@ func TestDecodeConfig_ColorModel_AllFormats(t *testing.T) {
 				}
 				return o
 			}(),
-			wantModel: color.YCbCrModel,
+			wantModel: color.NRGBAModel,
 		},
 		{
 			name: "lossless_with_exif",


### PR DESCRIPTION
## Summary

This PR fixes systematic black/white range contraction when decoding lossy WebP images and improves the performance of the corrected RGB output path, especially on amd64 and arm64.

Lossy VP8 stores pixels as limited-range BT.601 YUV. The previous decoder exposed those planes as Go `image.YCbCr`, whose conversion routines assume full-range JPEG YCbCr semantics. As a result, standard Go image consumers interpreted limited-range samples as full-range values:

- black was lifted;
- white was reduced;
- contrast and saturation were visibly compressed;
- repeated lossy WebP transcoding progressively made images grayer.

This PR converts lossy VP8 pixels to `image.NRGBA` during decoding with the correct limited-range BT.601 conversion.

## Root Cause

The problem was not ordinary WebP quantization, resizing, gamma correction, or ICC metadata handling.

The decoder returned raw VP8 YUV planes as `image.YCbCr`. However:

- VP8 uses limited/video-range luma and chroma;
- Go's `image.YCbCr` represents full-range JPEG-style YCbCr;
- `image.YCbCr` has no metadata for distinguishing limited and full range.

Consequently, a nominal VP8 black value around `Y=16` was interpreted as RGB 16 instead of RGB 0, while nominal white around `Y=235` was interpreted as RGB 235 instead of RGB 255.

On repeated decode/encode cycles, this error accumulated. A representative black/white sequence was:

```text
generation 1: 16 / 235
generation 2: 30 / 218
generation 3: 42 / 203
```

## Changes

- Decode lossy VP8 frames directly into `*image.NRGBA`.
- Apply WebP's limited-range BT.601 YUV-to-RGB conversion during decode.
- Preserve the existing diamond-shaped four-tap fancy chroma upsampling behavior.
- Preserve alpha-plane handling for extended lossy WebP images.
- Make `Decode`, `DecodeReuse`, animation frame decoding, and `DecodeConfig` consistently use the NRGBA color model.
- Continue reusing compatible NRGBA pixel buffers through `DecodeReuse`.

## AMD64 Optimization

The corrected decoder includes a dedicated amd64 fast path:

- AVX2 converts eight pixels per iteration when available.
- SSE2 converts four pixels per iteration and handles non-AVX2 systems and remainders.
- Scalar conversion is used only for the final tail.
- SIMD and scalar paths use the same fixed-point coefficients and remain bit-exact with the Go reference implementation.

The packed-UV scratch workspace is now allocated once per decoded image and reused across all row pairs:

- widths up to 2048 pixels use stack-backed scratch storage;
- larger images require only one heap allocation;
- repeated allocation and clearing for every pair of scanlines is eliminated.

In development benchmarks, scratch reuse improved the range-correct NRGBA decoder by approximately 6–7%.

This comparison is against the initial correct NRGBA implementation, not against the old YCbCr path with incorrect pixel semantics.

## ARM64 Optimization

The same reusable scratch interface is supported by the arm64 decoder, with NEON processing eight pixels per iteration.

Platforms without assembly support continue to use the pure-Go reference implementation.

## Validation

Added regression coverage for:

- encoded limited-range black and white fixtures;
- correct NRGBA output type;
- black channels remaining at or below 4;
- white channels remaining at or above 251;
- three consecutive lossy decode/encode generations without progressive range contraction;
- SIMD output matching the pure-Go reference across randomized widths and alpha combinations;
- odd image widths and single-row inputs;
- caller-provided scratch storage producing bit-identical output;
- compatible and incompatible `DecodeReuse` buffers.

The complete test suite passes with:

```bash
go test ./...
```

Downstream validation against native `dwebp` produced matching decoded color statistics, while the previous decoder showed clearly lifted RGB values.

## Compatibility Note

This intentionally changes the concrete return type for lossy images without alpha:

```text
Before: *image.YCbCr
After:  *image.NRGBA
```

`DecodeConfig.ColorModel` now reports `color.NRGBAModel` accordingly.

Code relying only on the `image.Image` interface is unaffected. Code asserting the concrete `*image.YCbCr` type must be updated.

This type change is necessary because Go's `image.YCbCr` cannot accurately describe VP8's limited-range YUV planes.